### PR TITLE
Workflow to build and push to RubyGems.org on release

### DIFF
--- a/.github/workflows/publish-rubygem.yml
+++ b/.github/workflows/publish-rubygem.yml
@@ -1,0 +1,24 @@
+name: Publish gem to RubyGems.org
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push:
+    name: "Build gem and run gem push"
+    runs-on: ubuntu-latest
+    env:
+      GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
+      BUILT_GEM_NAME: "govuk-design-system-rails-${{ github.ref_name }}.gem"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+      - name: Build and push
+        run: |
+          gem build govuk_design_system-rails.gemspec --output $BUILT_GEM_NAME
+          gem push $BUILT_GEM_NAME
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ${{ env.BUILT_GEM_NAME }}
+          retention-days: 7

--- a/.github/workflows/publish-rubygem.yml
+++ b/.github/workflows/publish-rubygem.yml
@@ -20,4 +20,4 @@ jobs:
           gem push $BUILT_GEM_NAME
       - uses: actions/upload-artifact@v3
         with:
-          path: "${{ env.BUILT_GEM_NAME }}"
+          path: ${{ env.BUILT_GEM_NAME }}

--- a/.github/workflows/publish-rubygem.yml
+++ b/.github/workflows/publish-rubygem.yml
@@ -20,5 +20,4 @@ jobs:
           gem push $BUILT_GEM_NAME
       - uses: actions/upload-artifact@v3
         with:
-          path: ${{ env.BUILT_GEM_NAME }}
-          retention-days: 7
+          path: "${{ env.BUILT_GEM_NAME }}"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (0.9.8)
+    govuk-design-system-rails (1.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (1.0.0)
+    govuk-design-system-rails (0.10.0)
 
 GEM
   remote: https://rubygems.org/
@@ -75,7 +75,7 @@ GEM
     date (3.3.3)
     diff-lcs (1.5.0)
     erubi (1.12.0)
-    globalid (1.0.1)
+    globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You **must** include the [govuk-frontend](https://github.com/alphagov/govuk-fron
 Add the following to your project's Gemfile:
 
 ```ruby
-gem "govuk-design-system-rails", git: "https://github.com/govuk-ruby/govuk-design-system-rails", tag: "0.9.9"
+gem "govuk-design-system-rails"
 ```
 and run `bundle install`
 

--- a/govuk-design-system-rails.gemspec
+++ b/govuk-design-system-rails.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name = "govuk-design-system-rails"
-  s.version = "0.9.8"
+  s.version = "1.0.0"
   s.authors = %w[govuk-ruby]
   s.summary = "An implementation of the govuk-frontend macros in Ruby on Rails"
   s.homepage = "https://github.com/govuk-ruby/govuk-design-system-rails"

--- a/govuk-design-system-rails.gemspec
+++ b/govuk-design-system-rails.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name = "govuk-design-system-rails"
-  s.version = "1.0.0"
+  s.version = "0.10.0"
   s.authors = %w[govuk-ruby]
   s.summary = "An implementation of the govuk-frontend macros in Ruby on Rails"
   s.homepage = "https://github.com/govuk-ruby/govuk-design-system-rails"


### PR DESCRIPTION
- When a Github release is tagged and published, this workflow will build the gem and push it to RubyGems.org (#69)
- Requires a new repository secret, `GEM_HOST_API_KEY` (see: https://guides.rubygems.org/publishing/)
- We should consider [signing the gem](https://guides.rubygems.org/security/)