### PR TITLE
Add classes to the checkbox fieldset

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (0.10.1)
+    govuk-design-system-rails (0.10.2)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You **must** include the [govuk-frontend](https://github.com/alphagov/govuk-fron
 
 | This gem's version | Compatible with `govuk-frontend` version |
 |--------------------| --- |
-| 0.9.7              | 4.3.1 |
+| 0.10.2             | 4.3.1 |
 | 0.9.0              | 4.1.0 |
 | 0.8.2              | 3.14.0 |
 

--- a/app/views/components/_govuk_checkboxes.html.erb
+++ b/app/views/components/_govuk_checkboxes.html.erb
@@ -118,7 +118,7 @@
 %>
 <%= tag.div class: form_group_classes do %>
   <% if has_fieldset %>
-    <%= govukFieldset(classes: "", describedBy: described_by.presence, legend: local_assigns[:fieldset][:legend], attributes: local_assigns[:fieldset]) { inner_html } %>
+    <%= govukFieldset(classes: local_assigns[:fieldset][:classes], describedBy: described_by.presence, legend: local_assigns[:fieldset][:legend], attributes: local_assigns[:fieldset]) { inner_html } %>
   <% else %>
     <%= inner_html %>
   <% end %>

--- a/govuk-design-system-rails.gemspec
+++ b/govuk-design-system-rails.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name = "govuk-design-system-rails"
-  s.version = "0.10.1"
+  s.version = "0.10.2"
   s.authors = %w[govuk-ruby]
   s.summary = "An implementation of the govuk-frontend macros in Ruby on Rails"
   s.homepage = "https://github.com/govuk-ruby/govuk-design-system-rails"

--- a/spec/helpers/govuk_design_system/checkboxes_helper_spec.rb
+++ b/spec/helpers/govuk_design_system/checkboxes_helper_spec.rb
@@ -142,5 +142,76 @@ RSpec.describe GovukDesignSystem::CheckboxesHelper, type: :helper do
         </div>
       HTML
     end
+
+    it "returns the correct HTML when there is a fieldset css class" do
+      html = helper.govukCheckboxes({
+        idPrefix: "waste",
+        name: "waste",
+        fieldset: {
+          legend: {
+            text: "Which types of waste do you transport?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          },
+          classes: "js-mutually-exclusive"
+        },
+        hint: {
+          text: "Select all that apply."
+        },
+        items: [
+          {
+            value: "carcasses",
+            text: "Waste from animal carcasses",
+            disable_ghost: true
+          },
+          {
+            value: "mines",
+            text: "Waste from mines or quarries",
+            disable_ghost: true
+          },
+          {
+            value: "farm",
+            text: "Farm or agricultural waste",
+            disable_ghost: true
+          }
+        ]
+      })
+
+      expect(html).to match_html(<<~HTML)
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset js-mutually-exclusive" aria-describedby="waste-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                Which types of waste do you transport?
+              </h1>
+            </legend>
+            <div id="waste-hint" class="govuk-hint">
+              Select all that apply.
+            </div>
+            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste" name="waste" type="checkbox" value="carcasses">
+                <label class="govuk-label govuk-checkboxes__label" for="waste">
+                  Waste from animal carcasses
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+                  Waste from mines or quarries
+                </label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+                <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+                  Farm or agricultural waste
+                </label>
+              </div>
+            </div>
+
+          </fieldset>
+        </div>
+      HTML
+    end
   end
 end


### PR DESCRIPTION
Allows classes to be assigned to the optional fieldset surrounding checkboxes.

Similar to https://github.com/govuk-ruby/govuk-design-system-rails/pull/61.