### PR TITLE
Restore rails `javascript_include_tag` to ensure correct nonce value

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (0.10.3)
+    govuk-design-system-rails (0.10.4)
 
 GEM
   remote: https://rubygems.org/

--- a/app/views/components/_govuk_select.html.erb
+++ b/app/views/components/_govuk_select.html.erb
@@ -97,11 +97,9 @@
       </button>
     <% end %>
 
-    <script nonce="true">
-      // <![CDATA[
-        window.callAutocompleteWhenReady(<%= local_assigns[:id].to_json.html_safe %>, { showAllValues: <%= local_assigns[:show_all_values].to_json.html_safe %> });
-      // ]]>
-    </script>
+    <%= javascript_tag nonce: true do -%>
+      window.callAutocompleteWhenReady("<%= local_assigns[:id] %>", {showAllValues: "<%= local_assigns[:show_all_values] %>"});
+    <% end -%>
   <% else %>
     <%= select %>
   <% end %>

--- a/govuk-design-system-rails.gemspec
+++ b/govuk-design-system-rails.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name = "govuk-design-system-rails"
-  s.version = "0.10.3"
+  s.version = "0.10.4"
   s.authors = %w[govuk-ruby]
   s.summary = "An implementation of the govuk-frontend macros in Ruby on Rails"
   s.homepage = "https://github.com/govuk-ruby/govuk-design-system-rails"


### PR DESCRIPTION
- This resolves an issue whereby the CSP in Cosmetics app blocked the accessible-autocomplete library

COSBETA-1949